### PR TITLE
fix: add missing `show_historic_incidents` to component bulk edit form

### DIFF
--- a/docs/release-notes/version-2.1.md
+++ b/docs/release-notes/version-2.1.md
@@ -2,6 +2,9 @@
 
 ## v2.1.2 (FUTURE)
 
+### Bug fixes
+* Add missing `show_historic_incidents` to component bulk edit form
+
 ---
 
 ## v2.1.1 (2023-02-17)

--- a/statuspage/components/forms/bulk.py
+++ b/statuspage/components/forms/bulk.py
@@ -26,6 +26,11 @@ class ComponentBulkEditForm(StatusPageModelBulkEditForm):
         widget=StaticSelect(),
         label='Component Group',
     )
+    show_historic_incidents = forms.NullBooleanField(
+        required=False,
+        widget=BulkEditNullBooleanSelect,
+        label='Show historic Incidents',
+    )
     visibility = forms.NullBooleanField(
         required=False,
         widget=BulkEditNullBooleanSelect,


### PR DESCRIPTION
Closes #472