### PR TITLE
revert: chore(deps): bump markdown from 3.3.7 to 3.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Markdown==3.4.1
+Markdown==3.3.7
 Pillow==9.3.0
 PyYAML==6.0
 bleach==5.0.1


### PR DESCRIPTION
Reverts Status-Page/Status-Page#441 due to version incompatibility.