### PR TITLE
chore(i18n): translations update from Status-Page Translate

### DIFF
--- a/statuspage/components/locale/de/LC_MESSAGES/django.po
+++ b/statuspage/components/locale/de/LC_MESSAGES/django.po
@@ -3,48 +3,50 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-03-29 13:12+0200\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2023-03-29 11:34+0000\n"
+"Last-Translator: Tobias Peltzer <admin@herrtxbias.net>\n"
+"Language-Team: German <http://translate.status-page.dev/projects/status-page/"
+"status-page-components/de/>\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.16.2\n"
+
 #: components/choices.py:12
 msgid "Expand on Issue"
-msgstr ""
+msgstr "Erweitern bei Problemen"
 
 #: components/choices.py:13
 msgid "Always Expanded"
-msgstr ""
+msgstr "Immer Erweitert"
 
 #: components/choices.py:28
 msgid "Unknown"
-msgstr ""
+msgstr "Unbekannt"
 
 #: components/choices.py:29
 msgid "Operational"
-msgstr ""
+msgstr "Funktionstüchtig"
 
 #: components/choices.py:30
 msgid "Degraded Performance"
-msgstr ""
+msgstr "Beeinträchtigte Leistung"
 
 #: components/choices.py:31
 msgid "Partial Outage"
-msgstr ""
+msgstr "Teilausfall"
 
 #: components/choices.py:32
 msgid "Major Outage"
-msgstr ""
+msgstr "Großer Ausfall"
 
 #: components/choices.py:33
 msgid "Maintenance"
-msgstr ""
+msgstr "Wartung"


### PR DESCRIPTION
Translations update from [Status-Page Translate](http://translate.status-page.dev) for [Status-Page/Status-Page Components](http://translate.status-page.dev/projects/status-page/status-page-components/).



Current translation status:

![Weblate translation status](http://translate.status-page.dev/widgets/status-page/-/status-page-components/horizontal-auto.svg)