### PR TITLE
chore(i18n): translations update from Status-Page Translate

### DIFF
--- a/statuspage/extras/locale/de/LC_MESSAGES/django.po
+++ b/statuspage/extras/locale/de/LC_MESSAGES/django.po
@@ -3,32 +3,34 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-03-29 13:12+0200\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2023-03-29 13:54+0000\n"
+"Last-Translator: Tobias Peltzer <admin@herrtxbias.net>\n"
+"Language-Team: German <http://translate.status-page.dev/projects/status-page/"
+"extras/de/>\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.16.2\n"
+
 #: extras/forms/filtersets.py:27
 msgid "After"
-msgstr ""
+msgstr "Nach"
 
 #: extras/forms/filtersets.py:32
 msgid "Before"
-msgstr ""
+msgstr "Vor"
 
 #: extras/forms/filtersets.py:43
 msgid "User"
-msgstr ""
+msgstr "Benutzer"
 
 #: extras/forms/filtersets.py:51
 msgid "Object Type"
-msgstr ""
+msgstr "Objekttyp"

--- a/statuspage/incidents/locale/de/LC_MESSAGES/django.po
+++ b/statuspage/incidents/locale/de/LC_MESSAGES/django.po
@@ -3,48 +3,50 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-03-29 15:33+0200\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2023-03-29 13:54+0000\n"
+"Last-Translator: Tobias Peltzer <admin@herrtxbias.net>\n"
+"Language-Team: German <http://translate.status-page.dev/projects/status-page/"
+"incidents/de/>\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.16.2\n"
+
 #: incidents/choices.py:14
 msgid "Investigating"
-msgstr ""
+msgstr "Untersuchen"
 
 #: incidents/choices.py:15
 msgid "Identified"
-msgstr ""
+msgstr "Identifiziert"
 
 #: incidents/choices.py:16
 msgid "Monitoring"
-msgstr ""
+msgstr "Überwachung"
 
 #: incidents/choices.py:17
 msgid "Resolved"
-msgstr ""
+msgstr "Erledigt"
 
 #: incidents/choices.py:30
 msgid "None"
-msgstr ""
+msgstr "Keine"
 
 #: incidents/choices.py:31
 msgid "Minor"
-msgstr ""
+msgstr "Kleinere"
 
 #: incidents/choices.py:32
 msgid "Major"
-msgstr ""
+msgstr "Major"
 
 #: incidents/choices.py:33
 msgid "Critical"
-msgstr ""
+msgstr "Kritisch"

--- a/statuspage/maintenances/locale/de/LC_MESSAGES/django.po
+++ b/statuspage/maintenances/locale/de/LC_MESSAGES/django.po
@@ -3,36 +3,38 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-03-29 15:33+0200\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2023-03-29 13:54+0000\n"
+"Last-Translator: Tobias Peltzer <admin@herrtxbias.net>\n"
+"Language-Team: German <http://translate.status-page.dev/projects/status-page/"
+"maintenances/de/>\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.16.2\n"
+
 #: maintenances/choices.py:14
 msgid "Scheduled"
-msgstr ""
+msgstr "Geplant"
 
 #: maintenances/choices.py:15
 msgid "In Progress"
-msgstr ""
+msgstr "In Arbeit"
 
 #: maintenances/choices.py:16
 msgid "Verifying"
-msgstr ""
+msgstr "Überprüfen Sie"
 
 #: maintenances/choices.py:17
 msgid "Completed"
-msgstr ""
+msgstr "Abgeschlossen"
 
 #: maintenances/choices.py:27
 msgid "Maintenance"
-msgstr ""
+msgstr "Wartung"

--- a/statuspage/statuspage/locale/de/LC_MESSAGES/django.po
+++ b/statuspage/statuspage/locale/de/LC_MESSAGES/django.po
@@ -3,44 +3,46 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-03-29 15:33+0200\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2023-03-29 13:54+0000\n"
+"Last-Translator: Tobias Peltzer <admin@herrtxbias.net>\n"
+"Language-Team: German <http://translate.status-page.dev/projects/status-page/"
+"status-page/de/>\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.16.2\n"
+
 #: statuspage/settings.py:250
 msgid "German"
-msgstr ""
+msgstr "Deutsch"
 
 #: statuspage/settings.py:251
 msgid "English"
-msgstr ""
+msgstr "Englisch"
 
 #: statuspage/views/__init__.py:95
 msgid "Some systems are undergoing maintenance"
-msgstr ""
+msgstr "Einige Systeme werden zur Zeit gewartet"
 
 #: statuspage/views/__init__.py:98
 msgid "There is a major system outage"
-msgstr ""
+msgstr "Es gibt einen größeren Systemausfall"
 
 #: statuspage/views/__init__.py:100
 msgid "There is a partial system outage"
-msgstr ""
+msgstr "Es gibt einen teilweisen Ausfall des Systems"
 
 #: statuspage/views/__init__.py:103
 msgid "Some systems are having perfomance issues"
-msgstr ""
+msgstr "Bei einigen Systemen treten Leistungsprobleme auf"
 
 #: statuspage/views/__init__.py:107
 msgid "All systems operational"
-msgstr ""
+msgstr "Alle Systeme betriebsbereit"


### PR DESCRIPTION
Translations update from [Status-Page Translate](http://translate.status-page.dev) for [Status-Page/Components](http://translate.status-page.dev/projects/status-page/components/).


It also includes following components:

* [Status-Page/Extras](http://translate.status-page.dev/projects/status-page/extras/)

* [Status-Page/Incidents](http://translate.status-page.dev/projects/status-page/incidents/)

* [Status-Page/Maintenances](http://translate.status-page.dev/projects/status-page/maintenances/)

* [Status-Page/Status-Page](http://translate.status-page.dev/projects/status-page/status-page/)



Current translation status:

![Weblate translation status](http://translate.status-page.dev/widgets/status-page/-/components/horizontal-auto.svg)