### PR TITLE
chore(i18n): translations update from Status-Page Translate

### DIFF
--- a/statuspage/incidents/locale/de/LC_MESSAGES/django.po
+++ b/statuspage/incidents/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-03-29 15:33+0200\n"
-"PO-Revision-Date: 2023-03-29 13:54+0000\n"
+"PO-Revision-Date: 2023-03-29 14:03+0000\n"
 "Last-Translator: Tobias Peltzer <admin@herrtxbias.net>\n"
 "Language-Team: German <http://translate.status-page.dev/projects/status-page/"
 "incidents/de/>\n"
@@ -45,7 +45,7 @@ msgstr "Kleinere"
 
 #: incidents/choices.py:32
 msgid "Major"
-msgstr "Major"
+msgstr "Wesentlich"
 
 #: incidents/choices.py:33
 msgid "Critical"


### PR DESCRIPTION
Translations update from [Status-Page Translate](http://translate.status-page.dev) for [Status-Page/Components](http://translate.status-page.dev/projects/status-page/components/).


It also includes following components:

* [Status-Page/Extras](http://translate.status-page.dev/projects/status-page/extras/)

* [Status-Page/Maintenances](http://translate.status-page.dev/projects/status-page/maintenances/)

* [Status-Page/Status-Page](http://translate.status-page.dev/projects/status-page/status-page/)

* [Status-Page/Incidents](http://translate.status-page.dev/projects/status-page/incidents/)



Current translation status:

![Weblate translation status](http://translate.status-page.dev/widgets/status-page/-/components/horizontal-auto.svg)